### PR TITLE
Possibility to tune disqusIdentifier

### DIFF
--- a/src/services.plugin.coffee
+++ b/src/services.plugin.coffee
@@ -354,10 +354,10 @@ module.exports = (BasePlugin) ->
 				return ''  unless disqusShortname
 				disqusDeveloper = if 'production' in @getEnvironments() then '0' else '1'
 				pageUrl = @getPageUrl()
-                if (@document.disqusIdentifier !== undefined)
-				    disqusIdentifier = @document.disqusIdentifier
-                else
-                    disqusIdentifier= @document.slug
+				if @document.disqusIdentifier isnt undefined
+					disqusIdentifier = @document.disqusIdentifier
+				else
+					disqusIdentifier = @document.slug
 				disqusTitle = @document.title or @document.name
 
 				# Return


### PR DESCRIPTION
When moving my blog from Jekyll to DocPad I faced the need to preserve Disqus comments which I already had to my posts. But I used different code to embed Disqus which did not provide `window.disqus_identifier`. Thus, to preserve comments I need now to define `window.disqus_identifier` as `undefined` for my older posts. I decided that this would be not very nice to modify `@document.slug` for this. So, I think this would be much better to have optional `disqusIdentifier` attribute which takes care of it.
