### PR TITLE
If there are apostrophes in the title, Disqus breaks

### DIFF
--- a/src/services.plugin.coffee
+++ b/src/services.plugin.coffee
@@ -355,7 +355,7 @@ module.exports = (BasePlugin) ->
 				disqusDeveloper = if 'production' in @getEnvironments() then '0' else '1'
 				pageUrl = @getPageUrl()
 				disqusIdentifier = @document.slug
-				disqusTitle = @document.title or @document.name
+				disqusTitle = (@document.title or @document.name).replace '\'', '\\\''
 
 				# Return
 				return """


### PR DESCRIPTION
You end up with a Disqus title that looks like this:

``` javascript
window.disqus_title = 'Stay Pure and Don't Become a Mutant';
```

Which doesn't work.

If we replace the apostrophe with an escaped version, it shows up in Disqus perfectly.
