### PR TITLE
Upgrading from legacy to container infrastructure.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,6 @@
 # February 19, 2015
 # https://github.com/bevry/base
+sudo: false
 language: node_js
 # ensure npm is the latest version (ignore node versions that can't run it)
 # ensure coffee-script is installed (needed for cake commands)


### PR DESCRIPTION
Reason for upgrading:

>  Pull Request #23 Possibility to tune disqusIdentifier
> 
>  Commit 6c19110
>  #23: Possibility to tune disqusIdentifier
> avatar Varya Stepanova authored and committed
> 
>  #33.1 errored
> 
>  Elapsed time 2 min 33 sec
>  2 years ago
> Restart Job
> **This job ran on our legacy infrastructure. Please read our docs on how to upgrade.**

https://travis-ci.org/docpad/docpad-plugin-services/jobs/25993927

_ _ _

Travis' doc on upgrading:

> tl;dr #
> 
> Not using sudo? Containers sound cool? Add `sudo: false` to `.travis.yml` and you’re set.

https://docs.travis-ci.com/user/migrating-from-legacy/?utm_source=legacy-notice&utm_medium=banner&utm_campaign=legacy-upgrade